### PR TITLE
Add Test Coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "ionic-app-scripts build",
     "ionic:build": "ionic-app-scripts build",
     "ionic:serve": "ionic-app-scripts serve",
-    "test": "karma start ./test-config/karma.conf.js"
+    "test": "karma start ./test-config/karma.conf.js",
+    "test-coverage": "karma start ./test-config/karma.conf.js --coverage"
   },
   "dependencies": {
     "@angular/common": "2.4.8",
@@ -38,9 +39,11 @@
     "@types/node": "^7.0.8",
     "angular2-template-loader": "^0.6.2",
     "html-loader": "^0.4.5",
+    "istanbul-instrumenter-loader": "^2.0.0",
     "jasmine": "^2.5.3",
     "karma": "^1.5.0",
     "karma-chrome-launcher": "^2.0.0",
+    "karma-coverage-istanbul-reporter": "^1.0.0",
     "karma-jasmine": "^1.1.0",
     "karma-jasmine-html-reporter": "^0.2.2",
     "karma-sourcemap-loader": "^0.3.7",

--- a/test-config/karma.conf.js
+++ b/test-config/karma.conf.js
@@ -30,7 +30,12 @@ module.exports = function (config) {
       terminal: true
     },
 
-    reporters: ['kjhtml', 'dots'],
+    coverageIstanbulReporter: {
+      reports: [ 'html', 'lcovonly' ],
+      fixWebpackSourcePaths: true
+    },
+
+    reporters: config.coverage ? ['kjhtml', 'dots', 'coverage-istanbul'] : ['kjhtml', 'dots'],
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,

--- a/test-config/webpack.test.js
+++ b/test-config/webpack.test.js
@@ -19,6 +19,15 @@ module.exports = {
         ]
       },
       {
+        test: /.+\.ts$/,
+        exclude: /(index.ts|mocks.ts|\.spec\.ts$)/,
+        loader: 'istanbul-instrumenter-loader',
+        enforce: 'post',
+        query: {
+          esModules: true
+        }
+      },
+      {
         test: /\.html$/,
         loader: 'html-loader'
       },


### PR DESCRIPTION
Followed the instructions on [karma-coverage-istanbul-reporter](https://github.com/mattlewis92/karma-coverage-istanbul-reporter#about) and in particular [this example config](https://github.com/mattlewis92/karma-coverage-istanbul-reporter/blob/master/test/karma.conf.js) to add the minimal changes required to get coverage working.

You need an additional webpack loader ([istanbul-instrumenter-loader](https://github.com/webpack-contrib/istanbul-instrumenter-loader)) and to add `karma-coverage-istanbul` as a reporter.

The reason I've added a separate script in package.json (`test-coverage`) is that coverage breaks the sourcemaps: https://github.com/angular/angular-cli/pull/1799 - so you don't want to run it all the time. Either that or you need an explicit debug as the ng-cli team did.  