### PR TITLE
fix(e2e): split e2e npm script into two

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ See the example test in `src/app/app.component.spec.ts` for an example of a comp
 End-To-End Tests (Browser-Only)
 -------------------------------
 
+To install and update the webdriver, run `npm run e2e-update`.
+
 To serve the app, run `ionic serve`.
 
 To run the end-to-end tests, run (while the app is being served) `npm run e2e`.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,6 @@ See the example test in `src/app/app.component.spec.ts` for an example of a comp
 End-To-End Tests (Browser-Only)
 -------------------------------
 
-To install and update the webdriver, run `npm run e2e-update`.
-
 To serve the app, run `ionic serve`.
 
 To run the end-to-end tests, run (while the app is being served) `npm run e2e`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "ionic:serve": "ionic-app-scripts serve",
     "test": "karma start ./test-config/karma.conf.js",
     "test-ci": "karma start ./test-config/karma.conf.js --single-run",
-    "e2e": "protractor ./test-config/protractor.conf.js",
+    "e2e": "npm run e2e-update && npm run e2e-test",
+    "e2e-test": "protractor ./test-config/protractor.conf.js",
     "e2e-update": "webdriver-manager update --standalone false --gecko false"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "ionic:serve": "ionic-app-scripts serve",
     "test": "karma start ./test-config/karma.conf.js",
     "test-ci": "karma start ./test-config/karma.conf.js --single-run",
-    "e2e": "webdriver-manager update --standalone false --gecko false; protractor ./test-config/protractor.conf.js"
+    "e2e": "protractor ./test-config/protractor.conf.js",
+    "e2e-update": "webdriver-manager update --standalone false --gecko false"
   },
   "dependencies": {
     "@angular/common": "4.1.2",


### PR DESCRIPTION
* npm script commands separated by semicolon don't work in Windows
* webdriver update doesn't need to be run every time