### PR TITLE
feat(mocks): added mocks that support tabs with lazy loading

### DIFF
--- a/test-config/mocks-ionic.ts
+++ b/test-config/mocks-ionic.ts
@@ -77,3 +77,39 @@ export class SplashScreenMock extends SplashScreen {
     return;
   }
 }
+
+export class NavMock {
+ 
+  public pop(): any {
+    return new Promise(function(resolve: Function): void {
+      resolve();
+    });
+  }
+ 
+  public push(): any {
+    return new Promise(function(resolve: Function): void {
+      resolve();
+    });
+  }
+ 
+  public getActive(): any {
+    return {
+      'instance': {
+        'model': 'something',
+      },
+    };
+  }
+ 
+  public setRoot(): any {
+    return true;
+  }
+
+  public registerChildNav(nav: any): void {
+    return ;
+  }
+
+}
+
+export class DeepLinkerMock {
+
+}


### PR DESCRIPTION
With the default setup, if you try to add tabs when using lazy loading your unit tests will error out. It's necessary to add the following providers:

```
{ provide: DeepLinker, useClass: DeepLinkerMock },
{ provide: NavController, useClass: NavMock },
```

and the NavMock must mock the `registerChildNav` function. I've added these mocks to the mocks-ionic.ts file.
