### PR TITLE
fix(mocks): update return signature for ready()

### DIFF
--- a/test-config/mocks-ionic.ts
+++ b/test-config/mocks-ionic.ts
@@ -2,7 +2,7 @@ import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
 
 export class PlatformMock {
-  public ready(): Promise<{String}> {
+  public ready(): Promise<string> {
     return new Promise((resolve) => {
       resolve('READY');
     });


### PR DESCRIPTION
Upon upgrading to the latest of several libraries (mostly Ionic and Angular),
I started getting this error:

```
typescript: test-config/mocks-ionic.ts, line: 7
Argument of type '"READY"' is not assignable to parameter of type '{ String: any; } | PromiseLike<{ String: any; }>'.
```

The signature as it was looked for the promise to resolve with an object
having a property called "String" which contained anything.

The actual signature found here:
https://github.com/ionic-team/ionic/blob/master/src/platform/platform.ts
calls for the promise to be resolved with a string, so this change makes the mock signature consistent.